### PR TITLE
Make package valid

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "test-git-fetch",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
+  "main": "dist/index.js",
   "scripts": {
     "prepare": "tsc src/index.ts --outDir dist && node append prepare",
     "prepublishOnly": "node append prepublishOnly",


### PR DESCRIPTION
This will make test cases pass when pnpm strips files which would not be part of a package when downloading from a git repo.